### PR TITLE
API methods for invite sending, receiving, and responding

### DIFF
--- a/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
+++ b/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
@@ -1,5 +1,6 @@
 package com.shopmate.api;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.shopmate.api.model.item.ShoppingListItem;
 import com.shopmate.api.model.list.ShoppingList;
@@ -20,9 +21,10 @@ public interface ShopMateService {
      *
      * @param fbToken The user's Facebook token.
      * @param title The title of the list to create.
+     * @param inviteUserIds The IDs of additional users to invite.
      * @return The actual shopping list that was created.
      */
-    ListenableFuture<CreateShoppingListResult> createListAsync(String fbToken, String title);
+    ListenableFuture<CreateShoppingListResult> createListAsync(String fbToken, String title, ImmutableSet<String> inviteUserIds);
 
     /**
      * Asynchronously gets information about a single shopping list and the items in it.

--- a/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
+++ b/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
@@ -92,4 +92,28 @@ public interface ShopMateService {
      * @return Information about the invite that was sent.
      */
     ListenableFuture<SendInviteResult> sendInvite(String fbToken, long listId, String receiverUserId);
+
+    /**
+     * Asynchronously accepts an invite that was sent to a user.
+     *
+     * @param fbToken The user's Facebook token.
+     * @param inviteId The ID of the invite to accept.
+     */
+    ListenableFuture<Void> acceptInvite(String fbToken, long inviteId);
+
+    /**
+     * Asynchronously declines an invite that was sent to a user.
+     *
+     * @param fbToken The user's Facebook token.
+     * @param inviteId The ID of the invite to decline.
+     */
+    ListenableFuture<Void> declineInvite(String fbToken, long inviteId);
+
+    /**
+     * Asynchronously cancels a pending invite that a user sent.
+     *
+     * @param fbToken The user's Facebook token.
+     * @param inviteId The ID of the invite to cancel.
+     */
+    ListenableFuture<Void> cancelInvite(String fbToken, long inviteId);
 }

--- a/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
+++ b/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
@@ -5,7 +5,9 @@ import com.shopmate.api.model.item.ShoppingListItem;
 import com.shopmate.api.model.list.ShoppingList;
 import com.shopmate.api.model.result.CreateShoppingListItemResult;
 import com.shopmate.api.model.result.CreateShoppingListResult;
+import com.shopmate.api.model.result.GetAllInvitesResult;
 import com.shopmate.api.model.result.GetAllShoppingListsResult;
+import com.shopmate.api.model.result.SendInviteResult;
 
 /**
  * Interface for an object which opens connections to the ShopMate API.
@@ -70,4 +72,22 @@ public interface ShopMateService {
      * @return The item.
      */
     ListenableFuture<ShoppingListItem> getItemAsync(String fbToken, long itemId);
+
+    /**
+     * Asynchronously gets all pending invites that the user has sent or received.
+     *
+     * @param fbToken The user's Facebook token.
+     * @return The invites.
+     */
+    ListenableFuture<GetAllInvitesResult> getAllInvites(String fbToken);
+
+    /**
+     * Asynchronously sends an invite for a user to join a list.
+     *
+     * @param fbToken The user's Facebook token.
+     * @param listId The ID of the list to send an invite for.
+     * @param receiverUserId The FBID of the user to send the invite to.
+     * @return Information about the invite that was sent.
+     */
+    ListenableFuture<SendInviteResult> sendInvite(String fbToken, long listId, String receiverUserId);
 }

--- a/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
+++ b/api-iface/src/main/java/com/shopmate/api/ShopMateService.java
@@ -91,7 +91,7 @@ public interface ShopMateService {
      * @param receiverUserId The FBID of the user to send the invite to.
      * @return Information about the invite that was sent.
      */
-    ListenableFuture<SendInviteResult> sendInvite(String fbToken, long listId, String receiverUserId);
+    ListenableFuture<SendInviteResult> sendInviteAsync(String fbToken, long listId, String receiverUserId);
 
     /**
      * Asynchronously accepts an invite that was sent to a user.
@@ -99,7 +99,7 @@ public interface ShopMateService {
      * @param fbToken The user's Facebook token.
      * @param inviteId The ID of the invite to accept.
      */
-    ListenableFuture<Void> acceptInvite(String fbToken, long inviteId);
+    ListenableFuture<Void> acceptInviteAsync(String fbToken, long inviteId);
 
     /**
      * Asynchronously declines an invite that was sent to a user.
@@ -107,7 +107,7 @@ public interface ShopMateService {
      * @param fbToken The user's Facebook token.
      * @param inviteId The ID of the invite to decline.
      */
-    ListenableFuture<Void> declineInvite(String fbToken, long inviteId);
+    ListenableFuture<Void> declineInviteAsync(String fbToken, long inviteId);
 
     /**
      * Asynchronously cancels a pending invite that a user sent.
@@ -115,5 +115,5 @@ public interface ShopMateService {
      * @param fbToken The user's Facebook token.
      * @param inviteId The ID of the invite to cancel.
      */
-    ListenableFuture<Void> cancelInvite(String fbToken, long inviteId);
+    ListenableFuture<Void> cancelInviteAsync(String fbToken, long inviteId);
 }

--- a/api-iface/src/main/java/com/shopmate/api/model/list/ShoppingListInvite.java
+++ b/api-iface/src/main/java/com/shopmate/api/model/list/ShoppingListInvite.java
@@ -1,0 +1,31 @@
+package com.shopmate.api.model.list;
+
+public class ShoppingListInvite {
+    private final long id;
+    private final String listTitle;
+    private final String senderId;
+    private final String receiverId;
+
+    public ShoppingListInvite(long id, String listTitle, String senderId, String receiverId) {
+        this.id = id;
+        this.listTitle = listTitle;
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getListTitle() {
+        return listTitle;
+    }
+
+    public String getSenderId() {
+        return senderId;
+    }
+
+    public String getReceiverId() {
+        return receiverId;
+    }
+}

--- a/api-iface/src/main/java/com/shopmate/api/model/result/GetAllInvitesResult.java
+++ b/api-iface/src/main/java/com/shopmate/api/model/result/GetAllInvitesResult.java
@@ -1,0 +1,30 @@
+package com.shopmate.api.model.result;
+
+import com.google.common.collect.ImmutableList;
+import com.shopmate.api.model.list.ShoppingListInvite;
+
+public class GetAllInvitesResult {
+    private final ImmutableList<ShoppingListInvite> incomingInvites;
+    private final ImmutableList<ShoppingListInvite> outgoingInvites;
+
+    public GetAllInvitesResult(
+            ImmutableList<ShoppingListInvite> incomingInvites,
+            ImmutableList<ShoppingListInvite> outgoingInvites) {
+        this.incomingInvites = incomingInvites;
+        this.outgoingInvites = outgoingInvites;
+    }
+
+    /**
+     * @return A list of invites that were sent to the user.
+     */
+    public ImmutableList<ShoppingListInvite> getIncomingInvites() {
+        return incomingInvites;
+    }
+
+    /**
+     * @return A list of invites that were sent by the user.
+     */
+    public ImmutableList<ShoppingListInvite> getOutgoingInvites() {
+        return outgoingInvites;
+    }
+}

--- a/api-iface/src/main/java/com/shopmate/api/model/result/SendInviteResult.java
+++ b/api-iface/src/main/java/com/shopmate/api/model/result/SendInviteResult.java
@@ -1,0 +1,13 @@
+package com.shopmate.api.model.result;
+
+public class SendInviteResult {
+    private final long id;
+
+    public SendInviteResult(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
+++ b/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
@@ -1,5 +1,6 @@
 package com.shopmate.api.net;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -11,18 +12,24 @@ import com.shopmate.api.model.item.ShoppingListItem;
 import com.shopmate.api.model.list.ShoppingList;
 import com.shopmate.api.model.result.CreateShoppingListItemResult;
 import com.shopmate.api.model.result.CreateShoppingListResult;
+import com.shopmate.api.model.result.GetAllInvitesResult;
 import com.shopmate.api.model.result.GetAllShoppingListsResult;
+import com.shopmate.api.model.result.SendInviteResult;
 import com.shopmate.api.net.model.list.ShoppingListJson;
 import com.shopmate.api.net.model.request.CreateItemRequest;
 import com.shopmate.api.net.model.request.CreateListRequest;
+import com.shopmate.api.net.model.request.GetAllInvitesRequest;
 import com.shopmate.api.net.model.request.GetAllListsRequest;
 import com.shopmate.api.net.model.request.GetListRequest;
+import com.shopmate.api.net.model.request.SendInviteRequest;
 import com.shopmate.api.net.model.response.ApiResponse;
 import com.shopmate.api.net.model.response.CreateItemResponse;
 import com.shopmate.api.net.model.response.ErrorCodes;
+import com.shopmate.api.net.model.response.GetAllInvitesResponse;
 import com.shopmate.api.net.model.response.GetAllListsResponse;
 import com.shopmate.api.net.model.response.GetItemResponse;
 import com.shopmate.api.net.model.response.GetListResponse;
+import com.shopmate.api.net.model.response.SendInviteResponse;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -40,6 +47,9 @@ public class NetShopMateService implements ShopMateService {
 
     private static final String CreateItemUrl = "/item/create";
     private static final String GetItemUrl = "/item/%s";
+
+    private static final String AllInvitesUrl = "/request/all";
+    private static final String SendInviteUrl = "/request/send";
 
     private static ListeningExecutorService ThreadPool =
             MoreExecutors.listeningDecorator(
@@ -61,7 +71,7 @@ public class NetShopMateService implements ShopMateService {
         return ThreadPool.submit(new Callable<CreateShoppingListResult>() {
             @Override
             public CreateShoppingListResult call() throws Exception {
-                CreateListRequest request = new CreateListRequest(fbToken, title);
+                CreateListRequest request = new CreateListRequest(fbToken, title, ImmutableList.<String>of());
                 Type responseType = new TypeToken<ApiResponse<ShoppingListJson>>(){}.getType();
                 ApiResponse<ShoppingListJson> response = post(CreateListUrl, request, responseType);
                 throwIfRequestFailed(response);
@@ -134,6 +144,34 @@ public class NetShopMateService implements ShopMateService {
                 ApiResponse<GetItemResponse> response = post(url, request, responseType);
                 throwIfRequestFailed(response);
                 return response.getResult().get().toItem();
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<GetAllInvitesResult> getAllInvites(final String fbToken) {
+        return ThreadPool.submit(new Callable<GetAllInvitesResult>() {
+            @Override
+            public GetAllInvitesResult call() throws Exception {
+                GetAllInvitesRequest request = new GetAllInvitesRequest(fbToken);
+                Type responseType = new TypeToken<ApiResponse<GetAllInvitesResponse>>(){}.getType();
+                ApiResponse<GetAllInvitesResponse> response = post(AllInvitesUrl, request, responseType);
+                throwIfRequestFailed(response);
+                return response.getResult().get().toResult();
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<SendInviteResult> sendInvite(final String fbToken, final long listId, final String receiverUserId) {
+        return ThreadPool.submit(new Callable<SendInviteResult>() {
+            @Override
+            public SendInviteResult call() throws Exception {
+                SendInviteRequest request = new SendInviteRequest(fbToken, listId, receiverUserId);
+                Type responseType = new TypeToken<ApiResponse<SendInviteResponse>>(){}.getType();
+                ApiResponse<SendInviteResponse> response = post(SendInviteUrl, request, responseType);
+                throwIfRequestFailed(response);
+                return response.getResult().get().toResult();
             }
         });
     }

--- a/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
+++ b/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
@@ -1,6 +1,6 @@
 package com.shopmate.api.net;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -67,11 +67,11 @@ public class NetShopMateService implements ShopMateService {
     }
 
     @Override
-    public ListenableFuture<CreateShoppingListResult> createListAsync(final String fbToken, final String title) {
+    public ListenableFuture<CreateShoppingListResult> createListAsync(final String fbToken, final String title, final ImmutableSet<String> inviteUserIds) {
         return ThreadPool.submit(new Callable<CreateShoppingListResult>() {
             @Override
             public CreateShoppingListResult call() throws Exception {
-                CreateListRequest request = new CreateListRequest(fbToken, title, ImmutableList.<String>of());
+                CreateListRequest request = new CreateListRequest(fbToken, title, inviteUserIds);
                 Type responseType = new TypeToken<ApiResponse<ShoppingListJson>>(){}.getType();
                 ApiResponse<ShoppingListJson> response = post(CreateListUrl, request, responseType);
                 throwIfRequestFailed(response);

--- a/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
+++ b/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
@@ -16,8 +16,11 @@ import com.shopmate.api.model.result.GetAllInvitesResult;
 import com.shopmate.api.model.result.GetAllShoppingListsResult;
 import com.shopmate.api.model.result.SendInviteResult;
 import com.shopmate.api.net.model.list.ShoppingListJson;
+import com.shopmate.api.net.model.request.AcceptInviteRequest;
+import com.shopmate.api.net.model.request.CancelInviteRequest;
 import com.shopmate.api.net.model.request.CreateItemRequest;
 import com.shopmate.api.net.model.request.CreateListRequest;
+import com.shopmate.api.net.model.request.DeclineInviteRequest;
 import com.shopmate.api.net.model.request.GetAllInvitesRequest;
 import com.shopmate.api.net.model.request.GetAllListsRequest;
 import com.shopmate.api.net.model.request.GetListRequest;
@@ -50,6 +53,9 @@ public class NetShopMateService implements ShopMateService {
 
     private static final String AllInvitesUrl = "/request/all";
     private static final String SendInviteUrl = "/request/send";
+    private static final String AcceptInviteUrl = "/request/%s/accept";
+    private static final String DeclineInviteUrl = "/request/%s/decline";
+    private static final String CancelInviteUrl = "/request/%s/cancel";
 
     private static ListeningExecutorService ThreadPool =
             MoreExecutors.listeningDecorator(
@@ -172,6 +178,51 @@ public class NetShopMateService implements ShopMateService {
                 ApiResponse<SendInviteResponse> response = post(SendInviteUrl, request, responseType);
                 throwIfRequestFailed(response);
                 return response.getResult().get().toResult();
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<Void> acceptInvite(final String fbToken, final long inviteId) {
+        return ThreadPool.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                AcceptInviteRequest request = new AcceptInviteRequest(fbToken);
+                String url = String.format(AcceptInviteUrl, inviteId);
+                Type responseType = new TypeToken<ApiResponse<Void>>(){}.getType();
+                ApiResponse<Void> response = post(url, request, responseType);
+                throwIfRequestFailed(response);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<Void> declineInvite(final String fbToken, final long inviteId) {
+        return ThreadPool.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                DeclineInviteRequest request = new DeclineInviteRequest(fbToken);
+                String url = String.format(DeclineInviteUrl, inviteId);
+                Type responseType = new TypeToken<ApiResponse<Void>>(){}.getType();
+                ApiResponse<Void> response = post(url, request, responseType);
+                throwIfRequestFailed(response);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<Void> cancelInvite(final String fbToken, final long inviteId) {
+        return ThreadPool.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                CancelInviteRequest request = new CancelInviteRequest(fbToken);
+                String url = String.format(CancelInviteUrl, inviteId);
+                Type responseType = new TypeToken<ApiResponse<Void>>(){}.getType();
+                ApiResponse<Void> response = post(url, request, responseType);
+                throwIfRequestFailed(response);
+                return null;
             }
         });
     }

--- a/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
+++ b/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
@@ -169,7 +169,7 @@ public class NetShopMateService implements ShopMateService {
     }
 
     @Override
-    public ListenableFuture<SendInviteResult> sendInvite(final String fbToken, final long listId, final String receiverUserId) {
+    public ListenableFuture<SendInviteResult> sendInviteAsync(final String fbToken, final long listId, final String receiverUserId) {
         return ThreadPool.submit(new Callable<SendInviteResult>() {
             @Override
             public SendInviteResult call() throws Exception {
@@ -183,7 +183,7 @@ public class NetShopMateService implements ShopMateService {
     }
 
     @Override
-    public ListenableFuture<Void> acceptInvite(final String fbToken, final long inviteId) {
+    public ListenableFuture<Void> acceptInviteAsync(final String fbToken, final long inviteId) {
         return ThreadPool.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
@@ -198,7 +198,7 @@ public class NetShopMateService implements ShopMateService {
     }
 
     @Override
-    public ListenableFuture<Void> declineInvite(final String fbToken, final long inviteId) {
+    public ListenableFuture<Void> declineInviteAsync(final String fbToken, final long inviteId) {
         return ThreadPool.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
@@ -213,7 +213,7 @@ public class NetShopMateService implements ShopMateService {
     }
 
     @Override
-    public ListenableFuture<Void> cancelInvite(final String fbToken, final long inviteId) {
+    public ListenableFuture<Void> cancelInviteAsync(final String fbToken, final long inviteId) {
         return ThreadPool.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception {

--- a/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
+++ b/api-net/src/main/java/com/shopmate/api/net/NetShopMateService.java
@@ -51,11 +51,11 @@ public class NetShopMateService implements ShopMateService {
     private static final String CreateItemUrl = "/item/create";
     private static final String GetItemUrl = "/item/%s";
 
-    private static final String AllInvitesUrl = "/request/all";
-    private static final String SendInviteUrl = "/request/send";
-    private static final String AcceptInviteUrl = "/request/%s/accept";
-    private static final String DeclineInviteUrl = "/request/%s/decline";
-    private static final String CancelInviteUrl = "/request/%s/cancel";
+    private static final String AllInvitesUrl = "/invite/all";
+    private static final String SendInviteUrl = "/invite/send";
+    private static final String AcceptInviteUrl = "/invite/%s/accept";
+    private static final String DeclineInviteUrl = "/invite/%s/decline";
+    private static final String CancelInviteUrl = "/invite/%s/cancel";
 
     private static ListeningExecutorService ThreadPool =
             MoreExecutors.listeningDecorator(

--- a/api-net/src/main/java/com/shopmate/api/net/model/list/ShoppingListInviteJson.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/list/ShoppingListInviteJson.java
@@ -1,0 +1,14 @@
+package com.shopmate.api.net.model.list;
+
+import com.shopmate.api.model.list.ShoppingListInvite;
+
+public class ShoppingListInviteJson {
+    private long id;
+    private String title = "";
+    private String senderFbid = "";
+    private String receiverFbid = "";
+
+    public ShoppingListInvite toInvite() {
+        return new ShoppingListInvite(id, title, senderFbid, receiverFbid);
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/model/list/ShoppingListJson.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/list/ShoppingListJson.java
@@ -14,6 +14,7 @@ public class ShoppingListJson {
     private String title = "";
     private String creator = "";
     private List<ShoppingListItemHandleJson> items = new ArrayList<>();
+    private List<String> members = new ArrayList<>();
 
     public ShoppingListJson() {
     }
@@ -22,7 +23,7 @@ public class ShoppingListJson {
         return new ShoppingList(
                 creator,
                 title,
-                ImmutableSet.<String>of(creator),
+                ImmutableSet.copyOf(members),
                 buildItemHandles());
     }
 

--- a/api-net/src/main/java/com/shopmate/api/net/model/request/AcceptInviteRequest.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/request/AcceptInviteRequest.java
@@ -1,0 +1,7 @@
+package com.shopmate.api.net.model.request;
+
+public class AcceptInviteRequest extends AuthenticatedRequest {
+    public AcceptInviteRequest(String token) {
+        super(token);
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/model/request/CancelInviteRequest.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/request/CancelInviteRequest.java
@@ -1,0 +1,7 @@
+package com.shopmate.api.net.model.request;
+
+public class CancelInviteRequest extends AuthenticatedRequest {
+    public CancelInviteRequest(String token) {
+        super(token);
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/model/request/CreateListRequest.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/request/CreateListRequest.java
@@ -1,10 +1,14 @@
 package com.shopmate.api.net.model.request;
 
+import com.google.common.collect.ImmutableList;
+
 public class CreateListRequest extends AuthenticatedRequest {
     private final String title;
+    private final ImmutableList<String> inviteFbids;
 
-    public CreateListRequest(String token, String title) {
+    public CreateListRequest(String token, String title, ImmutableList<String> inviteFbids) {
         super(token);
         this.title = title;
+        this.inviteFbids = inviteFbids;
     }
 }

--- a/api-net/src/main/java/com/shopmate/api/net/model/request/CreateListRequest.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/request/CreateListRequest.java
@@ -1,12 +1,12 @@
 package com.shopmate.api.net.model.request;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class CreateListRequest extends AuthenticatedRequest {
     private final String title;
-    private final ImmutableList<String> inviteFbids;
+    private final ImmutableSet<String> inviteFbids;
 
-    public CreateListRequest(String token, String title, ImmutableList<String> inviteFbids) {
+    public CreateListRequest(String token, String title, ImmutableSet<String> inviteFbids) {
         super(token);
         this.title = title;
         this.inviteFbids = inviteFbids;

--- a/api-net/src/main/java/com/shopmate/api/net/model/request/DeclineInviteRequest.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/request/DeclineInviteRequest.java
@@ -1,0 +1,7 @@
+package com.shopmate.api.net.model.request;
+
+public class DeclineInviteRequest extends AuthenticatedRequest {
+    public DeclineInviteRequest(String token) {
+        super(token);
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/model/request/GetAllInvitesRequest.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/request/GetAllInvitesRequest.java
@@ -1,0 +1,7 @@
+package com.shopmate.api.net.model.request;
+
+public class GetAllInvitesRequest extends AuthenticatedRequest {
+    public GetAllInvitesRequest(String fbToken) {
+        super(fbToken);
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/model/request/SendInviteRequest.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/request/SendInviteRequest.java
@@ -1,0 +1,12 @@
+package com.shopmate.api.net.model.request;
+
+public class SendInviteRequest extends AuthenticatedRequest {
+    private final long listId;
+    private final String receiverFbid;
+
+    public SendInviteRequest(String token, long listId, String receiverFbid) {
+        super(token);
+        this.listId = listId;
+        this.receiverFbid = receiverFbid;
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/model/response/GetAllInvitesResponse.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/response/GetAllInvitesResponse.java
@@ -1,0 +1,26 @@
+package com.shopmate.api.net.model.response;
+
+import com.google.common.collect.ImmutableList;
+import com.shopmate.api.model.list.ShoppingListInvite;
+import com.shopmate.api.model.result.GetAllInvitesResult;
+import com.shopmate.api.net.model.list.ShoppingListInviteJson;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetAllInvitesResponse {
+    private List<ShoppingListInviteJson> incoming = new ArrayList<>();
+    private List<ShoppingListInviteJson> outgoing = new ArrayList<>();
+
+    public GetAllInvitesResult toResult() {
+        return new GetAllInvitesResult(convertInvites(incoming), convertInvites(outgoing));
+    }
+
+    private static ImmutableList<ShoppingListInvite> convertInvites(List<ShoppingListInviteJson> invites) {
+        List<ShoppingListInvite> result = new ArrayList<>();
+        for (ShoppingListInviteJson invite : invites) {
+            result.add(invite.toInvite());
+        }
+        return ImmutableList.copyOf(result);
+    }
+}

--- a/api-net/src/main/java/com/shopmate/api/net/model/response/SendInviteResponse.java
+++ b/api-net/src/main/java/com/shopmate/api/net/model/response/SendInviteResponse.java
@@ -1,0 +1,11 @@
+package com.shopmate.api.net.model.response;
+
+import com.shopmate.api.model.result.SendInviteResult;
+
+public class SendInviteResponse {
+    private long id;
+
+    public SendInviteResult toResult() {
+        return new SendInviteResult(id);
+    }
+}

--- a/api-net/src/test/java/NetShopMateServiceTest.java
+++ b/api-net/src/test/java/NetShopMateServiceTest.java
@@ -208,6 +208,111 @@ public class NetShopMateServiceTest {
         Assert.assertEquals(invite2.getReceiverId(), TestId2);
     }
 
+    @Test
+    public void testSendingAndAcceptingInvite() throws ExecutionException, InterruptedException {
+        // make sure test user 2 has an ID
+        service.getAllListsNoItemsAsync(TestToken2).get();
+
+        CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName, ImmutableSet.<String>of()).get();
+        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+        long inviteId = sentInvite.getId();
+
+        GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
+        int outgoingIndex1 = indexOfInviteById(allInvites1.getOutgoingInvites(), inviteId);
+        int incomingIndex1 = indexOfInviteById(allInvites1.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex1 >= 0);
+        Assert.assertTrue(incomingIndex1 < 0);
+
+        GetAllInvitesResult allInvites2 = service.getAllInvites(TestToken2).get();
+        int outgoingIndex2 = indexOfInviteById(allInvites2.getOutgoingInvites(), inviteId);
+        int incomingIndex2 = indexOfInviteById(allInvites2.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex2 < 0);
+        Assert.assertTrue(incomingIndex2 >= 0);
+
+        service.acceptInvite(TestToken2, inviteId).get();
+
+        allInvites1 = service.getAllInvites(TestToken).get();
+        allInvites2 = service.getAllInvites(TestToken2).get();
+        outgoingIndex1 = indexOfInviteById(allInvites1.getOutgoingInvites(), inviteId);
+        incomingIndex2 = indexOfInviteById(allInvites2.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex1 < 0);
+        Assert.assertTrue(incomingIndex2 < 0);
+
+        ShoppingList list = service.getListAndItemsAsync(TestToken, createdList.getId()).get();
+        Assert.assertTrue(list.getMemberIds().contains(TestId));
+        Assert.assertTrue(list.getMemberIds().contains(TestId2));
+    }
+
+    @Test
+    public void testSendingAndCancelingInvite() throws ExecutionException, InterruptedException {
+        // make sure test user 2 has an ID
+        service.getAllListsNoItemsAsync(TestToken2).get();
+
+        CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName, ImmutableSet.<String>of()).get();
+        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+        long inviteId = sentInvite.getId();
+
+        GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
+        int outgoingIndex1 = indexOfInviteById(allInvites1.getOutgoingInvites(), inviteId);
+        int incomingIndex1 = indexOfInviteById(allInvites1.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex1 >= 0);
+        Assert.assertTrue(incomingIndex1 < 0);
+
+        GetAllInvitesResult allInvites2 = service.getAllInvites(TestToken2).get();
+        int outgoingIndex2 = indexOfInviteById(allInvites2.getOutgoingInvites(), inviteId);
+        int incomingIndex2 = indexOfInviteById(allInvites2.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex2 < 0);
+        Assert.assertTrue(incomingIndex2 >= 0);
+
+        service.cancelInvite(TestToken, inviteId).get();
+
+        allInvites1 = service.getAllInvites(TestToken).get();
+        allInvites2 = service.getAllInvites(TestToken2).get();
+        outgoingIndex1 = indexOfInviteById(allInvites1.getOutgoingInvites(), inviteId);
+        incomingIndex2 = indexOfInviteById(allInvites2.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex1 < 0);
+        Assert.assertTrue(incomingIndex2 < 0);
+
+        ShoppingList list = service.getListAndItemsAsync(TestToken, createdList.getId()).get();
+        Assert.assertTrue(list.getMemberIds().contains(TestId));
+        Assert.assertFalse(list.getMemberIds().contains(TestId2));
+    }
+
+    @Test
+    public void testSendingAndDecliningInvite() throws ExecutionException, InterruptedException {
+        // make sure test user 2 has an ID
+        service.getAllListsNoItemsAsync(TestToken2).get();
+
+        CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName, ImmutableSet.<String>of()).get();
+        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+        long inviteId = sentInvite.getId();
+
+        GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
+        int outgoingIndex1 = indexOfInviteById(allInvites1.getOutgoingInvites(), inviteId);
+        int incomingIndex1 = indexOfInviteById(allInvites1.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex1 >= 0);
+        Assert.assertTrue(incomingIndex1 < 0);
+
+        GetAllInvitesResult allInvites2 = service.getAllInvites(TestToken2).get();
+        int outgoingIndex2 = indexOfInviteById(allInvites2.getOutgoingInvites(), inviteId);
+        int incomingIndex2 = indexOfInviteById(allInvites2.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex2 < 0);
+        Assert.assertTrue(incomingIndex2 >= 0);
+
+        service.declineInvite(TestToken2, inviteId).get();
+
+        allInvites1 = service.getAllInvites(TestToken).get();
+        allInvites2 = service.getAllInvites(TestToken2).get();
+        outgoingIndex1 = indexOfInviteById(allInvites1.getOutgoingInvites(), inviteId);
+        incomingIndex2 = indexOfInviteById(allInvites2.getIncomingInvites(), inviteId);
+        Assert.assertTrue(outgoingIndex1 < 0);
+        Assert.assertTrue(incomingIndex2 < 0);
+
+        ShoppingList list = service.getListAndItemsAsync(TestToken, createdList.getId()).get();
+        Assert.assertTrue(list.getMemberIds().contains(TestId));
+        Assert.assertFalse(list.getMemberIds().contains(TestId2));
+    }
+
     private static int indexOfInviteById(ImmutableList<ShoppingListInvite> invites, long id) {
         for (int i = 0; i < invites.size(); i++) {
             if (invites.get(i).getId() == id) {

--- a/api-net/src/test/java/NetShopMateServiceTest.java
+++ b/api-net/src/test/java/NetShopMateServiceTest.java
@@ -4,9 +4,12 @@ import com.shopmate.api.model.item.ShoppingListItemBuilder;
 import com.shopmate.api.model.item.ShoppingListItemHandle;
 import com.shopmate.api.model.item.ShoppingListItemPriority;
 import com.shopmate.api.model.list.ShoppingList;
+import com.shopmate.api.model.list.ShoppingListInvite;
 import com.shopmate.api.model.result.CreateShoppingListItemResult;
 import com.shopmate.api.model.result.CreateShoppingListResult;
+import com.shopmate.api.model.result.GetAllInvitesResult;
 import com.shopmate.api.model.result.GetAllShoppingListsResult;
+import com.shopmate.api.model.result.SendInviteResult;
 import com.shopmate.api.net.NetShopMateService;
 
 import org.junit.Assert;
@@ -19,8 +22,11 @@ public class NetShopMateServiceTest {
 
     // Set this to a token from a test user for testing to work...
     // TODO: Create a dummy token on the server or something which always validates?
-    private static final String TestToken = "EAAQZAwjV0NNsBACC1T7QzZAwzlZA4TCB0wX20jpG4vZBgaTiSpLSkoYD53OEXrqyHmsLPq5miW1FgZC7YgFZB9zRtZChpvV8s2bTSyWFGZC6yKpEwZCDVGjGJeODTeL82BxTFwEueQZAsBRYZAzZAMsdKZCwVNHyGIplO53MsccuL3JSJDrikd03ZAqnKR";
+    private static final String TestToken = "EAAQZAwjV0NNsBABSykBY7svBtKNXaVszqzF5MefJOuK45R4No03QdTZCRZB5i36lladoTGZB9lWmNAgY16OONxcUEFE6z573gRogRTnLUb1wO5lNsNFWMvkWufWSGZC7YK2BZAmRyzJ1uMwIHnVYsd20ZCZA0F1KxDmwiQq7jE1XbUS2MAlU67WK";
     private static final String TestId = "136682413460238";
+
+    private static final String TestToken2 = "EAAQZAwjV0NNsBAEtywCse4WFZBmVPVgF3xVNvmZAC0HnkhPncH871ZA7nMYwTfVTnQZBKaGbtduCWZBCy21E7ZC7cQRdKqpHJEjKP77FOX2xsm1qhIVMXJ1rFHZAMdZAwrc4qFJnilJLKDKqJEkS3FfxjEZCBpHJAiZAu1qxviCbmeHwBmEN8vf5u2T";
+    private static final String TestId2 = "132318773909242";
 
     private static final String TestListName = "Test List";
 
@@ -125,5 +131,70 @@ public class NetShopMateServiceTest {
         Assert.assertEquals(testItem.getQuantity(), gotItem.getQuantity());
         Assert.assertEquals(testItem.getQuantityPurchased(), gotItem.getQuantityPurchased());
         Assert.assertEquals(testItem.getPriority(), gotItem.getPriority());
+    }
+
+    @Test
+    public void testGettingAllInvites() throws ExecutionException, InterruptedException {
+        checkInvites(TestToken, TestId);
+        checkInvites(TestToken2, TestId2);
+    }
+
+    private void checkInvites(String fbToken, String fbid) throws ExecutionException, InterruptedException {
+        GetAllInvitesResult allInvites = service.getAllInvites(fbToken).get();
+        for (ShoppingListInvite invite : allInvites.getIncomingInvites()) {
+            Assert.assertEquals(fbid, invite.getReceiverId());
+        }
+        for (ShoppingListInvite invite : allInvites.getOutgoingInvites()) {
+            Assert.assertEquals(fbid, invite.getSenderId());
+        }
+    }
+
+    @Test
+    public void testSendingAndGettingInvite() throws ExecutionException, InterruptedException {
+        // make sure test user 2 has an ID
+        service.getAllListsNoItemsAsync(TestToken2).get();
+
+        CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName).get();
+        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+
+        GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
+        boolean foundOutgoing1 = false, foundIncoming1 = false;
+        for (ShoppingListInvite invite : allInvites1.getOutgoingInvites()) {
+            if (invite.getId() == sentInvite.getId()) {
+                foundOutgoing1 = true;
+                Assert.assertEquals(invite.getListTitle(), TestListName);
+                Assert.assertEquals(invite.getSenderId(), TestId);
+                Assert.assertEquals(invite.getReceiverId(), TestId2);
+                break;
+            }
+        }
+        for (ShoppingListInvite invite : allInvites1.getIncomingInvites()) {
+            if (invite.getId() == sentInvite.getId()) {
+                foundIncoming1 = true;
+                break;
+            }
+        }
+        Assert.assertTrue(foundOutgoing1);
+        Assert.assertFalse(foundIncoming1);
+
+        GetAllInvitesResult allInvites2 = service.getAllInvites(TestToken2).get();
+        boolean foundOutgoing2 = false, foundIncoming2 = false;
+        for (ShoppingListInvite invite : allInvites2.getIncomingInvites()) {
+            if (invite.getId() == sentInvite.getId()) {
+                foundIncoming2 = true;
+                Assert.assertEquals(invite.getListTitle(), TestListName);
+                Assert.assertEquals(invite.getSenderId(), TestId);
+                Assert.assertEquals(invite.getReceiverId(), TestId2);
+                break;
+            }
+        }
+        for (ShoppingListInvite invite : allInvites2.getOutgoingInvites()) {
+            if (invite.getId() == sentInvite.getId()) {
+                foundOutgoing2 = true;
+                break;
+            }
+        }
+        Assert.assertTrue(foundIncoming2);
+        Assert.assertFalse(foundOutgoing2);
     }
 }

--- a/api-net/src/test/java/NetShopMateServiceTest.java
+++ b/api-net/src/test/java/NetShopMateServiceTest.java
@@ -158,7 +158,7 @@ public class NetShopMateServiceTest {
         service.getAllListsNoItemsAsync(TestToken2).get();
 
         CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName, ImmutableSet.<String>of()).get();
-        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+        SendInviteResult sentInvite = service.sendInviteAsync(TestToken, createdList.getId(), TestId2).get();
         long inviteId = sentInvite.getId();
 
         GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
@@ -214,7 +214,7 @@ public class NetShopMateServiceTest {
         service.getAllListsNoItemsAsync(TestToken2).get();
 
         CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName, ImmutableSet.<String>of()).get();
-        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+        SendInviteResult sentInvite = service.sendInviteAsync(TestToken, createdList.getId(), TestId2).get();
         long inviteId = sentInvite.getId();
 
         GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
@@ -229,7 +229,7 @@ public class NetShopMateServiceTest {
         Assert.assertTrue(outgoingIndex2 < 0);
         Assert.assertTrue(incomingIndex2 >= 0);
 
-        service.acceptInvite(TestToken2, inviteId).get();
+        service.acceptInviteAsync(TestToken2, inviteId).get();
 
         allInvites1 = service.getAllInvites(TestToken).get();
         allInvites2 = service.getAllInvites(TestToken2).get();
@@ -249,7 +249,7 @@ public class NetShopMateServiceTest {
         service.getAllListsNoItemsAsync(TestToken2).get();
 
         CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName, ImmutableSet.<String>of()).get();
-        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+        SendInviteResult sentInvite = service.sendInviteAsync(TestToken, createdList.getId(), TestId2).get();
         long inviteId = sentInvite.getId();
 
         GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
@@ -264,7 +264,7 @@ public class NetShopMateServiceTest {
         Assert.assertTrue(outgoingIndex2 < 0);
         Assert.assertTrue(incomingIndex2 >= 0);
 
-        service.cancelInvite(TestToken, inviteId).get();
+        service.cancelInviteAsync(TestToken, inviteId).get();
 
         allInvites1 = service.getAllInvites(TestToken).get();
         allInvites2 = service.getAllInvites(TestToken2).get();
@@ -284,7 +284,7 @@ public class NetShopMateServiceTest {
         service.getAllListsNoItemsAsync(TestToken2).get();
 
         CreateShoppingListResult createdList = service.createListAsync(TestToken, TestListName, ImmutableSet.<String>of()).get();
-        SendInviteResult sentInvite = service.sendInvite(TestToken, createdList.getId(), TestId2).get();
+        SendInviteResult sentInvite = service.sendInviteAsync(TestToken, createdList.getId(), TestId2).get();
         long inviteId = sentInvite.getId();
 
         GetAllInvitesResult allInvites1 = service.getAllInvites(TestToken).get();
@@ -299,7 +299,7 @@ public class NetShopMateServiceTest {
         Assert.assertTrue(outgoingIndex2 < 0);
         Assert.assertTrue(incomingIndex2 >= 0);
 
-        service.declineInvite(TestToken2, inviteId).get();
+        service.declineInviteAsync(TestToken2, inviteId).get();
 
         allInvites1 = service.getAllInvites(TestToken).get();
         allInvites2 = service.getAllInvites(TestToken2).get();

--- a/app/src/main/java/com/shopmate/shopmate/MainActivity.java
+++ b/app/src/main/java/com/shopmate/shopmate/MainActivity.java
@@ -26,6 +26,7 @@ import com.facebook.GraphResponse;
 import com.facebook.HttpMethod;
 import com.facebook.login.widget.LoginButton;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.shopmate.api.ShopMateServiceProvider;
@@ -138,7 +139,8 @@ public class MainActivity extends AppCompatActivity
             @Override
             public void onClick(View v) {
                 String fbToken = AccessToken.getCurrentAccessToken().getToken();
-                Futures.addCallback(ShopMateServiceProvider.get().createListAsync(fbToken, "New List" + Integer.toString(i++)), new FutureCallback<CreateShoppingListResult>() {
+                ImmutableSet<String> invites = ImmutableSet.of();
+                Futures.addCallback(ShopMateServiceProvider.get().createListAsync(fbToken, "New List" + Integer.toString(i++), invites), new FutureCallback<CreateShoppingListResult>() {
                     @Override
                     public void onSuccess(CreateShoppingListResult result) {
                         final String tmp = result.getList().getTitle();


### PR DESCRIPTION
This add 5 new API methods that you can use:
- `getAllInvitesAsync` - Get all of the user's pending invites
- `sendInviteAsync` - Sends an invite for a user to join a list
- `acceptInviteAsync` - Accepts an invite that was sent to a user
- `declineInviteAsync` - Declines an invite that was sent to a user
- `cancelInviteAsync` - Cancels a pending invite that a user sent

List APIs were also updated to include membership information and the ability to send invites when creating a list.

All tested and working correctly. We just need UIs now. :)